### PR TITLE
Additional check to include whether or not the given value is a number

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,10 +8,15 @@
 
 const isOdd = require('is-odd')
 const isIsOdd = require('is-is-odd')
+const isNumber = require('is-number');
 global.jQuery = require('jquery');
 require('jquery-basic-arithmetic-plugin')
 
 module.exports = function(val) {
+  if (!isNumber(val)) {
+    return false;
+  }
+
   if (isIsOdd(isOdd)) {
     try {
       if (isOdd(val)) {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "is-is-odd": "^1.0.2",
     "is-odd": "^3.0.1",
+    "is-number": "^7.0.0",
     "jquery": "^3.4.1",
     "jquery-basic-arithmetic-plugin": "^1.1.0"
   }

--- a/spec/unit.spec.js
+++ b/spec/unit.spec.js
@@ -24,8 +24,24 @@ describe('is 10', () => {
 });
 
 describe('A value that is not even a number', () => {
-    it('should return false', () => {
+    it('should return false for Infinity', () => {
         expect(isTen(Infinity)).toEqual(false);
+    });
+
+    it('should return false for a function', () => {
+        expect(isTen(() => {})).toEqual(false);
+    });
+
+    it('should return false for null', () => {
+        expect(isTen(null)).toEqual(false);
+    });
+
+    it('should return false for an array of singleton 10', () => {
+        expect(isTen([10])).toEqual(false);
+    });
+
+    it('should return false for an array of 10 items', () => {
+        expect(isTen([1, 2, 3, 4, 5, 6, 7, 8, 9, 0])).toEqual(false);
     });
 });
 

--- a/spec/unit.spec.js
+++ b/spec/unit.spec.js
@@ -2,7 +2,7 @@
  * Unit tests for the is 10 module
  */
 
-const isTen = require('../')
+const isTen = require('../');
 
 
 describe('is 10', () => {
@@ -20,6 +20,12 @@ describe('is 10', () => {
         notTen.forEach(x => {
             expect(isTen(x)).toEqual(false)
         });
+    });
+});
+
+describe('A value that is not even a number', () => {
+    it('should return false', () => {
+        expect(isTen(Infinity)).toEqual(false);
     });
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -62,6 +62,11 @@ is-number@^6.0.0:
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-6.0.0.tgz#e6d15ad31fc262887cccf217ae5f9316f81b1995"
   integrity sha512-Wu1VHeILBK8KAWJUAiSZQX94GmOE45Rg6/538fKwiloUu21KncEkYGPqob2oSZ5mUT73vLGrHQjKw3KMPwfDzg==
 
+is-number@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
+  integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
+
 is-odd@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/is-odd/-/is-odd-3.0.1.tgz#65101baf3727d728b66fa62f50cda7f2d3989601"


### PR DESCRIPTION
The reason why I believe these changes are a beneficial addition to this repo is the complexity of computing tenness could increase as this project grows. I believe that doing a simple validation check to include whether or not the given value is even a number is a valuable addition to this code base before we begin our main tennness check. 

I pulled in another valuable open source project called `is-number` and there is additional documentation about this repo [here](https://github.com/jonschlinkert/is-number). This repo accepts quite a bit of inputs for numbers. They are all listed in the read me but [here is the list of items that pass the `is-number` check](https://github.com/jonschlinkert/is-number/blob/master/test.js#L16-L99). As you can see this list is quite comprehensive. 